### PR TITLE
generate and package jni lib in jar + load lib from jar without assuming it in java.library.path

### DIFF
--- a/circe-crc32c-sse42/pom.xml
+++ b/circe-crc32c-sse42/pom.xml
@@ -53,36 +53,99 @@
         <groupId>com.github.maven-nar</groupId>
         <artifactId>nar-maven-plugin</artifactId>
         <extensions>true</extensions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <version>2.4.1</version>
         <configuration>
-          <runtime>${nar.runtime}</runtime>
-          <libraries>
-            <library>
-              <type>jni</type>
-              <narSystemPackage>com.scurrilous.circe.crc</narSystemPackage>
-            </library>
-          </libraries>
-          <cpp>
-            <optionSet>${nar.cpp.optionSet}</optionSet>
-            <exceptions>false</exceptions>
-            <rtti>false</rtti>
-            <optimize>full</optimize>
-          </cpp>
+          <descriptors>
+            <descriptor>src/main/assembly/assembly.xml</descriptor>
+          </descriptors>
+          <appendAssemblyId>false</appendAssemblyId>
         </configuration>
+        <executions>
+          <execution>
+            <id>make-assembly</id>
+            <phase>package</phase>
+            <goals>
+              <goal>single</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>
 
   <profiles>
     <profile>
-      <id>test-direct-access</id>
-      <dependencies>
-        <dependency>
-          <groupId>com.scurrilous</groupId>
-          <artifactId>circe-direct-access</artifactId>
-          <version>${project.version}</version>
-          <scope>test</scope>
-        </dependency>
-      </dependencies>
+      <id>mac</id>
+      <activation>
+        <os>
+          <name>Mac OS X</name>
+        </os>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>com.github.maven-nar</groupId>
+            <artifactId>nar-maven-plugin</artifactId>
+            <version>3.1.0</version>
+            <extensions>true</extensions>
+            <configuration>
+              <runtime>${nar.runtime}</runtime>
+              <output>circe-crc32c-sse42</output>
+              <libraries>
+                <library>
+                  <type>jni</type>
+                </library>
+              </libraries>
+              <cpp>
+                <optionSet>${nar.cpp.optionSet}</optionSet>
+                <exceptions>false</exceptions>
+                <rtti>false</rtti>
+                <optimize>full</optimize>
+              </cpp>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>Linux</id>
+      <activation>
+        <os>
+          <name>Linux</name>
+        </os>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>com.github.maven-nar</groupId>
+            <artifactId>nar-maven-plugin</artifactId>
+            <version>3.1.0</version>
+            <extensions>true</extensions>
+            <configuration>
+              <runtime>${nar.runtime}</runtime>
+              <output>circe-crc32c-sse42</output>
+              <libraries>
+                <library>
+                  <type>jni</type>
+                </library>
+              </libraries>
+              <cpp>
+                <optionSet>${nar.cpp.optionSet}</optionSet>
+                <exceptions>false</exceptions>
+                <rtti>false</rtti>
+                <optimize>full</optimize>
+              </cpp>
+              <linker>
+                <libSet>rt</libSet>
+              </linker>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
     </profile>
   </profiles>
 </project>

--- a/circe-crc32c-sse42/src/main/assembly/assembly.xml
+++ b/circe-crc32c-sse42/src/main/assembly/assembly.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<assembly>
+  <id>all</id>
+  <formats>
+    <format>jar</format>
+  </formats>
+
+  <includeBaseDirectory>false</includeBaseDirectory>
+  <dependencySets>
+    <dependencySet>
+      <excludes>
+        <exclude>com.scurrilous</exclude>
+        <exclude>*:nar:*</exclude>
+      </excludes>
+    </dependencySet>
+  </dependencySets>
+  <fileSets>
+    <fileSet>
+      <directory>${project.build.directory}/nar/${project.artifactId}-${project.version}-${os.arch}-MacOSX-gpp-jni/lib/${os.arch}-MacOSX-gpp/jni
+      </directory>
+      <outputDirectory>lib</outputDirectory>
+      <includes>
+        <include>lib*</include>
+      </includes>
+    </fileSet>
+    <fileSet>
+      <directory>${project.build.directory}/nar/${project.artifactId}-${project.version}-${os.arch}-Linux-gpp-jni/lib/${os.arch}-Linux-gpp/jni
+      </directory>
+      <outputDirectory>lib</outputDirectory>
+      <includes>
+        <include>lib*</include>
+      </includes>
+    </fileSet>
+    <fileSet>
+      <directory>${project.build.directory}/nar/${project.artifactId}-${project.version}-${os.arch}-${os.name}-gpp-jni/lib/${os.arch}-${os.name}-gpp/jni
+      </directory>
+      <outputDirectory>lib</outputDirectory>
+      <includes>
+        <include>lib*</include>
+      </includes>
+    </fileSet>
+    <fileSet>
+      <directory>${project.build.directory}/classes</directory>
+      <outputDirectory></outputDirectory>
+      <includes>
+        <include>**/*</include>
+      </includes>
+    </fileSet>
+  </fileSets>
+</assembly>

--- a/circe-crc32c-sse42/src/main/java/com/scurrilous/circe/crc/LibraryUtils.java
+++ b/circe-crc32c-sse42/src/main/java/com/scurrilous/circe/crc/LibraryUtils.java
@@ -1,0 +1,90 @@
+package com.scurrilous.circe.crc;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.Locale;
+
+/**
+ * provides utility to load libraries at runtime.
+ *
+ */
+public class LibraryUtils {
+
+    public static final String OS_NAME = System.getProperty("os.name").toLowerCase(Locale.US);
+
+    /**
+     * loads given library from the this jar. ie: this jar contains:
+     * /lib/libcirce-crc32c-sse42.jnilib
+     * 
+     * @param path
+     *            : absolute path of the library in the jar <br/>
+     *            if this jar contains: /lib/libcirce-crc32c-sse42.jnilib then
+     *            provide the same absolute path as input
+     * @throws Exception
+     */
+    public static void loadLibraryFromJar(String path) throws Exception {
+
+        if (!path.startsWith("/")) {
+            throw new IllegalArgumentException("absolute path must start with  /");
+        }
+
+        String[] parts = path.split("/");
+        String filename = (parts.length > 0) ? parts[parts.length - 1] : null;
+
+        File dir = File.createTempFile("native", "");
+        dir.delete();
+        if (!(dir.mkdir())) {
+            throw new IOException("Failed to create temp directory " + dir.getAbsolutePath());
+        }
+        dir.deleteOnExit();
+        File temp = new File(dir, filename);
+        temp.deleteOnExit();
+
+        byte[] buffer = new byte[1024];
+        int read;
+
+        InputStream input = LibraryUtils.class.getResourceAsStream(path);
+        if (input == null) {
+            throw new FileNotFoundException("Couldn't find file into jar " + path);
+        }
+
+        OutputStream out = new FileOutputStream(temp);
+        try {
+            while ((read = input.read(buffer)) != -1) {
+                out.write(buffer, 0, read);
+            }
+        } finally {
+            out.close();
+            input.close();
+        }
+
+        if (!temp.exists()) {
+            throw new FileNotFoundException("Failed to copy file from jar at " + temp.getAbsolutePath());
+        }
+
+        System.load(temp.getAbsolutePath());
+    }
+
+    /**
+     * Returns jni library extension based on OS specification. Maven-nar
+     * generates jni library based on different OS :
+     * http://mark.donszelmann.org/maven-nar-plugin/aol.html (jni.extension)
+     * 
+     * @return library type based on operating system
+     */
+    public static String libType() {
+
+        if (OS_NAME.indexOf("mac") >= 0) {
+            return "jnilib";
+        } else if (OS_NAME.indexOf("nix") >= 0 || OS_NAME.indexOf("nux") >= 0 || OS_NAME.indexOf("aix") > 0) {
+            return "so";
+        } else if (OS_NAME.indexOf("win") >= 0) {
+            return "dll";
+        }
+        throw new TypeNotPresentException(OS_NAME + " not supported", null);
+    }
+}

--- a/circe-crc32c-sse42/src/main/java/com/scurrilous/circe/crc/Sse42Crc32C.java
+++ b/circe-crc32c-sse42/src/main/java/com/scurrilous/circe/crc/Sse42Crc32C.java
@@ -20,6 +20,7 @@ import java.nio.ByteBuffer;
 import com.scurrilous.circe.IncrementalIntHash;
 import com.scurrilous.circe.impl.AbstractIncrementalIntHash;
 import com.scurrilous.circe.params.CrcParameters;
+import static com.scurrilous.circe.crc.LibraryUtils.*;
 
 /**
  * Implementation of CRC-32C using the SSE 4.2 CRC instruction.
@@ -30,7 +31,7 @@ public final class Sse42Crc32C extends AbstractIncrementalIntHash implements Inc
 
     private static boolean checkSupported() {
         try {
-            NarSystem.loadLibrary();
+            loadLibraryFromJar("/lib/libcirce-crc32c-sse42." + libType());
             return nativeSupported();
         } catch (final Exception | UnsatisfiedLinkError e) {
             return false;


### PR DESCRIPTION
**Can't use artifact as it as:**
When we build [circe-crc32c-sse42](https://github.com/trevorr/circe/tree/master/circe-crc32c-sse42) using maven build:
- It internally generates "jni" library based on OS where we build and it packages this generated `jni` library under `.nar` artifact. e.g: `circe-crc32c-sse42.nar`
- [Nar Plugin goal](https://github.com/trevorr/circe/blob/master/circe-crc32c-sse42/pom.xml#L61) also generates `NarSystem.java` which tries to load this `jni` library at runtime using `System.loadLibrary("circe-crc32c-sse42-0.1-SNAPSHOT");` which fails obviously because it asks  `ClassLoader`  to load library from `java.library.path` or `sun.boot.library.path`. And as this `jni` library is packaged under `.nar` so, definitely it is not present in either `library.path` and hence, initialization of the interface which provides API to compute checksum [Sse42Crc32C.java](https://github.com/trevorr/circe/blob/master/circe-crc32c-sse42/src/main/java/com/scurrilous/circe/crc/Sse42Crc32C.java#L33) fails.

**Solution**
- So, I created a pull request : which generates `circe-crc32c-sse42.jar` instead `circe-crc32c-sse42.nar` artifact and internally loads generated `jni` library without messing up with `library.path` and user can use this artifact without performing any additional magic.
  I have also added a [test case](https://github.com/rdhabalia/circe/blob/d5f7e0453d345cfa9897aa03b550fe1399796ecc/circe-common-test/src/test/java/com/scurrilous/circe/Crc32cSSE42Test.java) which cleanly uses `Sse42Crc32C.java` to compute checksum by simply adding dependency of artifact `com.scurrilous:circe-crc32c-sse42:${project.version}` and without worrying about configuring `library.path`. 
